### PR TITLE
Fixed typo for SEO canonical url field key

### DIFF
--- a/pages/[...permalink].vue
+++ b/pages/[...permalink].vue
@@ -151,7 +151,7 @@ const metadata = computed(() => {
 		title: pageData?.seo?.title ?? pageData?.title ?? undefined,
 		description: pageData?.seo?.meta_description ?? pageData?.summary ?? undefined,
 		image: globals.og_image ? fileUrl(globals.og_image) : undefined,
-		canonical: pageData?.seo?.canonical ?? url,
+		canonical: pageData?.seo?.canonical_url ?? url,
 	};
 });
 


### PR DESCRIPTION
The canonical url field key in the SEO collection is canonical_url, not canonical alone.